### PR TITLE
feat(search): Rangeify search matches for remote treesitter with prelabelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,39 @@ require("flash").jump({continue = true})
 
 </details>
 
+<details><summary>Remote Treesitter with prelabelling</summary>
+Start by typing a search pattern as with any other jump. The nodes around the
+matches of that pattern will be labelled in the same way as `treesitter` mode.
+You may hit the label key at any time to select that node. The labels are
+assigned to not conflict with the search pattern, just as in normal jump mode.
+
+```lua
+      {
+        "R",
+        mode = "o",
+        desc = "remote ts",
+        function()
+          require("flash").remote {
+            mode = "remote_ts",
+            matcher = require "flash.plugins.flat_map"(require("flash.plugins.treesitter").get_nodes),
+          }
+        end,
+      },
+      {
+        "R",
+        mode = "x",
+        desc = "remote ts",
+        function()
+          require("flash").jump {
+            mode = "remote_ts",
+            matcher = require "flash.plugins.flat_map"(require("flash.plugins.treesitter").get_nodes),
+          }
+        end,
+      },
+```
+
+</details>
+
 ## 🌈 Highlights
 
 | Group           | Default      | Description    |

--- a/lua/flash/plugins/flat_map.lua
+++ b/lua/flash/plugins/flat_map.lua
@@ -1,0 +1,34 @@
+local Search = require("flash.search")
+local Matcher = require("flash.search.matcher")
+
+-- Takes Search matches and runs a flat_map over it to get ranges
+return function(mapper)
+  ---@class Flash.FlatMap: Flash.Matcher
+  ---@field search Flash.Search
+  local R = {}
+
+  function R.new(win, state)
+    local self = setmetatable(Matcher.new(win), { __index = R })
+    self.search = Search.new(win, state)
+    return self
+  end
+
+  function R:get(opts)
+    self.matches = {}
+    for _, m in ipairs(self.search:get(opts)) do
+      vim.list_extend(self.matches, mapper(self.win, m.pos, m.end_pos))
+    end
+    return self.matches
+  end
+
+  function R:labels(labels)
+    return self.search:labels(labels)
+  end
+
+  return setmetatable(R, {
+    __call = function(_, win, state)
+      return R.new(win, state)
+    end,
+    __index = Matcher,
+  })
+end


### PR DESCRIPTION
- The Search matcher can take a `rangeify` function that can map the search match to one or more ranges that are all labelled for jumping (or selecting)
   - May want to make this able to return zero ranges to skip the current match too
- `remote_ts` mode is added that uses the treesitter containing nodes to map search matches to treesitter nodes, thus we can search and select treesitter nodes in one fell swoop (the labels are shown earlier than the current example in the readme)
- Also the remote plugin is enhanced so if the jump step has `config.jump.pos = "range"` then there is no second operator-pending mode to select the textobject, it directly uses the range of the jump step.

One open question is what happens to equal ranges in the labelling step? Is that wasting labels?

Maybe the `rangeify` argument should go in `search.rangeify` becuase it is modifying the behaviour of searching?