### PR TITLE
Remote plugin enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,61 +534,6 @@ require("flash").jump({continue = true})
 
 </details>
 
-<details><summary>Swap with remote</summary>
-
-Swap between two ranges using `rx<motion1><flash><motion2>` or `v<motion1>rx<flash><motion2>`
-
-```lua
-local swap_with = function(opts, ma, mb)
-  local function helper(start, finish, op)
-    vim.api.nvim_win_set_cursor(0, start)
-    vim.cmd "normal! v"
-    vim.api.nvim_win_set_cursor(0, finish)
-    vim.api.nvim_feedkeys(op or "p", "ni", false)
-  end
-
-  local reg = vim.fn.getreg '"'
-  vim.api.nvim_feedkeys("`" .. ma .. "v`" .. mb .. "y", "n", false)
-  local start, finish = vim.api.nvim_buf_get_mark(0, ma), vim.api.nvim_buf_get_mark(0, mb)
-
-  _G.__remote_op_opfunc = function() helper(vim.api.nvim_buf_get_mark(0, "["), vim.api.nvim_buf_get_mark(0, "]")) end
-  vim.go.operatorfunc = "v:lua.__remote_op_opfunc"
-  vim.api.nvim_feedkeys("g@", "n", false)
-  require("flash").remote(vim.tbl_deep_extend("force", {
-    remote = {
-      on_restore = vim.schedule_wrap(function()
-        helper(start, finish)
-        vim.fn.setreg('"', reg)
-      end),
-    },
-  }, opts))
-end
-M.swap_with = function(opts)
-  local v = vim.api.nvim_get_mode().mode:lower() == "v"
-  if v then
-    swap_with(opts, "<", ">")
-  else
-    _G.__remote_op_opfunc = function() swap_with(opts, v and "<" or "[", v and ">" or "]") end
-    vim.go.operatorfunc = "v:lua.__remote_op_opfunc"
-    vim.api.nvim_feedkeys("g@", "n", false)
-  end
-end
-
--- Add keymapping
-  {
-    "rx",
-    mode = { "x", "n" },
-    desc = "Remote Exchange",
-    function()
-      M.swap_with {
-        -- Customize the flash remote options for selecting the second range
-      }
-    end,
-  },
-```
-
-</details>
-
 ## 🌈 Highlights
 
 | Group           | Default      | Description    |

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -164,6 +164,7 @@ local defaults = {
       zindex = 1000,
     },
   },
+  remote = {},
 }
 
 ---@type Flash.Config

--- a/lua/flash/plugins/remote.lua
+++ b/lua/flash/plugins/remote.lua
@@ -66,12 +66,21 @@ end
 function M.jump(opts)
   M.save()
 
-  opts = Config.get(opts, { mode = "remote" }, {
+  opts = Config.get({ mode = "remote" }, opts, {
     action = function(match)
       vim.api.nvim_set_current_win(match.win)
-      vim.api.nvim_win_set_cursor(match.win, match.pos)
-      vim.go.operatorfunc = "v:lua.require'flash.plugins.remote'.op"
-      vim.api.nvim_feedkeys("g@", "n", false)
+      if opts.jump.pos == "range" then
+        vim.api.nvim_buf_set_mark(0, "[", match.pos[1], match.pos[2], {})
+        vim.api.nvim_buf_set_mark(0, "]", match.end_pos[1], match.end_pos[2], {})
+        M.op()
+      else
+        vim.api.nvim_win_set_cursor(
+          match.win,
+          opts.jump.pos == "start" and match.pos or match.end_pos
+        )
+        vim.go.operatorfunc = "v:lua.require'flash.plugins.remote'.op"
+        vim.api.nvim_feedkeys("g@", "n", false)
+      end
     end,
   })
 

--- a/lua/flash/state.lua
+++ b/lua/flash/state.lua
@@ -15,6 +15,7 @@ local Prompt = require("flash.prompt")
 ---@field matcher? fun(win: window, state:Flash.State): Flash.Match[]
 ---@field pattern? string
 ---@field labeler? fun(matches:Flash.Match[], state:Flash.State)
+---@field remote? {on_restore?: fun()}
 
 ---@class Flash.State
 ---@field win window


### PR DESCRIPTION
1. Jump to end_pos and jump to range correctly. Jumping to range no longer has a separate textobject step. As mentioned in the other PR I don't really see a reason you would configure the jumper to jump to a range and then ignore that range to select a textobject. This has good synergy with the remote treesitter example from the other PR. 

2. `on_restore` callback to perform custom actions on returning the cursor. Also added an example to the README of using this to create a "Remote Exchange" plugin