### PR TITLE
Separate highlight range from match jump range

### DIFF
--- a/lua/flash/highlight.lua
+++ b/lua/flash/highlight.lua
@@ -119,10 +119,11 @@ function M.update(state)
     local buf = vim.api.nvim_win_get_buf(match.win)
 
     if state.opts.highlight.matches then
-      vim.api.nvim_buf_set_extmark(buf, state.ns, match.pos[1] - 1, match.pos[2], {
-        end_row = match.end_pos[1] - 1,
-        end_col = match.end_pos[2] + 1,
-        hl_group = target and match.pos == target.pos and state.opts.highlight.groups.current
+      local hi = match.highlight_range or match
+      vim.api.nvim_buf_set_extmark(buf, state.ns, hi.pos[1] - 1, hi.pos[2], {
+        end_row = hi.end_pos[1] - 1,
+        end_col = hi.end_pos[2] + 1,
+        hl_group = target and hi.pos == target.pos and state.opts.highlight.groups.current
           or state.opts.highlight.groups.match,
         strict = false,
         priority = state.opts.highlight.priority + 1,

--- a/lua/flash/plugins/treesitter.lua
+++ b/lua/flash/plugins/treesitter.lua
@@ -7,7 +7,8 @@ local M = {}
 
 ---@param win window
 ---@param pos? Pos
-function M.get_nodes(win, pos)
+---@param end_pos? Pos
+function M.get_nodes(win, pos, end_pos)
   local buf = vim.api.nvim_win_get_buf(win)
   local line_count = vim.api.nvim_buf_line_count(buf)
 
@@ -36,6 +37,7 @@ function M.get_nodes(win, pos)
     local match = {
       pos = { range[1] + 1, range[2] },
       end_pos = { range[3] + 1, range[4] - 1 },
+      highlight_range = end_pos and { pos = pos, end_pos = end_pos },
       first = first,
     }
     first = false

--- a/lua/flash/search/matcher.lua
+++ b/lua/flash/search/matcher.lua
@@ -5,6 +5,11 @@ local Pos = require("flash.search.pos")
 ---@field pos Pos -- (1,0) indexed
 ---@field end_pos Pos -- (1,0) indexed
 ---@field label? string
+---@field highlight_range? Flash.HighlightRange
+
+---@class Flash.HighlightRange
+---@field pos Pos -- (1,0) indexed
+---@field end_pos Pos -- (1,0) indexed
 
 ---@alias Flash.Match.Find {forward?:boolean, wrap?:boolean, count?:number, pos?: Pos, match?:Flash.Match}
 


### PR DESCRIPTION
If `match` has `.highlight_range` then `highlight.matches` will use that for highlighting. Again, for the synergy with remote treesitter style plugins from the other PR.