### PR TITLE
Fix issue with jump labels when reg recording/executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Install the plugin with your preferred package manager:
   opts = {},
   -- stylua: ignore
   keys = {
-    { "s", mode = { "n", "o", "x" }, function() require("flash").jump() end, desc = "Flash" },
-    { "S", mode = { "n", "o", "x" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
+    { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
+    { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
     { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
     { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },
     { "<c-s>", mode = { "c" }, function() require("flash").toggle() end, desc = "Toggle Flash Search" },
@@ -251,8 +251,12 @@ Install the plugin with your preferred package manager:
         -- autohide flash when in operator-pending mode
         opts.autohide = vim.fn.mode(true):find("no") and vim.v.operator == "y"
 
-        -- disable jump labels when enabled and when using a count
-        opts.jump_labels = opts.jump_labels and vim.v.count == 0
+        -- disable jump labels when not enabled, when using a count,
+        -- or when recording/executing registers
+        opts.jump_labels = opts.jump_labels
+          and vim.v.count == 0
+          and vim.fn.reg_executing() == ""
+          and vim.fn.reg_recording() == ""
 
         -- Show jump labels only in operator-pending mode
         -- opts.jump_labels = vim.v.count == 0 and vim.fn.mode(true):find("o")

--- a/doc/flash.nvim.txt
+++ b/doc/flash.nvim.txt
@@ -240,8 +240,10 @@ Default Settings ~
             -- autohide flash when in operator-pending mode
             opts.autohide = vim.fn.mode(true):find("no") and vim.v.operator == "y"
     
-            -- disable jump labels when enabled and when using a count
-            opts.jump_labels = opts.jump_labels and vim.v.count == 0
+	    -- disable jump labels when not enabled, when using a count,
+	    -- and when recording/executing registers
+	    opts.jump_labels = opts.jump_labels and vim.v.count == 0 and
+		vim.fn.reg_executing() == "" and vim.fn.reg_recording() == ""
     
             -- Show jump labels only in operator-pending mode
             -- opts.jump_labels = vim.v.count == 0 and vim.fn.mode(true):find("o")

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -164,8 +164,10 @@ local defaults = {
         -- autohide flash when in operator-pending mode
         opts.autohide = vim.fn.mode(true):find("no") and vim.v.operator == "y"
 
-        -- disable jump labels when enabled and when using a count
-        opts.jump_labels = opts.jump_labels and vim.v.count == 0
+        -- disable jump labels when not enabled, when using a count,
+        -- and when recording/executing registers
+        opts.jump_labels = opts.jump_labels and vim.v.count == 0 and
+            vim.fn.reg_executing() == "" and vim.fn.reg_recording() == ""
 
         -- Show jump labels only in operator-pending mode
         -- opts.jump_labels = vim.v.count == 0 and vim.fn.mode(true):find("o")

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -165,9 +165,11 @@ local defaults = {
         opts.autohide = vim.fn.mode(true):find("no") and vim.v.operator == "y"
 
         -- disable jump labels when not enabled, when using a count,
-        -- and when recording/executing registers
-        opts.jump_labels = opts.jump_labels and vim.v.count == 0 and
-            vim.fn.reg_executing() == "" and vim.fn.reg_recording() == ""
+        -- or when recording/executing registers
+        opts.jump_labels = opts.jump_labels
+          and vim.v.count == 0
+          and vim.fn.reg_executing() == ""
+          and vim.fn.reg_recording() == ""
 
         -- Show jump labels only in operator-pending mode
         -- opts.jump_labels = vim.v.count == 0 and vim.fn.mode(true):find("o")

--- a/lua/flash/docs.lua
+++ b/lua/flash/docs.lua
@@ -20,7 +20,7 @@ function M.suggested()
     -- stylua: ignore
     keys = {
       { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
-      { "S", mode = { "n", "o", "x" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
+      { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
       { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
       { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },
       { "<c-s>", mode = { "c" }, function() require("flash").toggle() end, desc = "Toggle Flash Search" },


### PR DESCRIPTION
When recording and jump labels are set to true for "f" etc, then the following happens -
 (1) it ends on insert mode even though escape is pressed, which is a lot of fun
 (2) it is much slower to show and there is no use for them during recording and execution

This PR changes the behavior to disable jump labels if we are recording / executing. 