### PR TITLE
feat: enable multi window in vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,6 @@ Install the plugin with your preferred package manager:
 - **VS Code**: some functionality is changed/disabled when running **flash** in **VS Code**:
   - `prompt` is disabled
   - `highlights` are set to different defaults that will actually work in VS Code
-  - `search.multi_window` is disabled, since VS Code has problems with `vim.api.nvim_set_current_win`
 
 ## 📡 API
 

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -327,7 +327,6 @@ function M.get(...)
 
   if vim.g.vscode then
     ret.prompt.enabled = false
-    ret.search.multi_window = false
   end
   return ret
 end


### PR DESCRIPTION
vscode-neovim supports `nvim_set_current_win` now. https://github.com/vscode-neovim/vscode-neovim/releases/tag/v0.5.0