### PR TITLE
feat(vscode): show prompt in status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Install the plugin with your preferred package manager:
 - **jump**: `require("flash").jump(opts?)` opens **flash** with the given options
   - type any number of characters before typing a jump label
 - **VS Code**: some functionality is changed/disabled when running **flash** in **VS Code**:
-  - `prompt` is disabled
+  - `prompt` will show in the status bar
   - `highlights` are set to different defaults that will actually work in VS Code
 
 ## 📡 API

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -329,9 +329,6 @@ function M.get(...)
     ret.config(ret)
   end
 
-  if vim.g.vscode then
-    ret.prompt.enabled = false
-  end
   return ret
 end
 

--- a/lua/flash/prompt.lua
+++ b/lua/flash/prompt.lua
@@ -1,5 +1,35 @@
 local Config = require("flash.config")
 
+if vim.g.vscode then
+  local prompt
+  pcall(function() -- The current extension version may not have this API
+    prompt = require("vscode-neovim").get_status_item("flash.nvim")
+  end)
+
+  return {
+    show = function() end,
+    hide = function()
+      if prompt then
+        prompt.text = ""
+      end
+    end,
+    ---@param pattern string
+    set = function(pattern)
+      if prompt then
+        local text = vim.deepcopy(Config.prompt.prefix)
+        text[#text + 1] = { pattern }
+
+        local str = ""
+        for _, item in ipairs(text) do
+          str = str .. item[1]
+        end
+
+        prompt.text = str
+      end
+    end,
+  }
+end
+
 ---@class Flash.Prompt
 ---@field win window
 ---@field buf buffer


### PR DESCRIPTION
In vscode-neovim 1.0.0, a new API has been added to use vscode's statusBar. https://github.com/vscode-neovim/vscode-neovim#lua

![status](https://github.com/vscode-neovim/vscode-neovim/assets/47070852/e727674b-8b9a-45e1-9ac3-05206511a6bc)