### PR TITLE
feat(treesitter): include parent tree in addition to injected tree for Treesitter node selections

### DIFF
--- a/lua/flash/plugins/treesitter.lua
+++ b/lua/flash/plugins/treesitter.lua
@@ -41,6 +41,18 @@ function M.get_nodes(win, pos)
       nodes[#nodes + 1] = node
       node = node:parent() ---@type TSNode
     end
+
+    -- if previous nodes come from injections, get all ranges outside the injections, too
+    node = tree:named_node_for_range({ pos[1] - 1, pos[2], pos[1] - 1, pos[2] }, {
+      ignore_injections = true,
+    })
+
+    if node and nodes[1]:id() ~= node:id() then
+      while node do
+        nodes[#nodes + 1] = node
+        node = node:parent() ---@type TSNode
+      end
+    end
   end
 
   -- convert ranges to matches


### PR DESCRIPTION
I often have a situation where I want treesitter node selections to select outside the injections.

Here's a screenshot from `:lua require("flash").treesitter({ highlight = { backdrop = true } })` in a markdown code block.

![image](https://github.com/folke/flash.nvim/assets/30277794/d40637f8-c299-46c7-8a6c-4d5bf122b26a)

Note that the similar features are available in https://github.com/ggandor/leap-ast.nvim and https://github.com/mfussenegger/nvim-treehopper .
