### PR TITLE
feat(char): add auto-jump/auto-motion option when using labels, closes #183

### DIFF
--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -205,7 +205,12 @@ local defaults = {
       end,
       search = { wrap = false },
       highlight = { backdrop = true },
-      jump = { register = false },
+      jump = {
+        register = false,
+        -- when using jump labels, set to 'true' to automatically jump
+        -- or execute a motion when there is only one match
+        autojump = false,
+      },
     },
     -- options used for treesitter selections
     -- `require("flash").treesitter()`

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -240,7 +240,11 @@ function M.jump(key)
   jump()
   M.state:update({ force = true })
 
-  if M.jump_labels and (not M.state.opts.modes.char.jump.autojump or #M.state.results ~= 1) then
+  if M.jump_labels then
+    if (Config.get("char").jump.autojump and #M.state.results == 1) then
+      M.state:hide()
+      return M.state
+    end
     parsed.actions[Util.CR] = function()
       return false
     end

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -240,7 +240,7 @@ function M.jump(key)
   jump()
   M.state:update({ force = true })
 
-  if M.jump_labels then
+  if M.jump_labels and (not M.state.opts.modes.char.jump.autojump or #M.state.results ~= 1) then
     parsed.actions[Util.CR] = function()
       return false
     end


### PR DESCRIPTION
A naive solution for https://github.com/folke/flash.nvim/issues/183 I've been using locally. 

Currently can be enabled by setting **autojump** to **true**

```
modes = {
    char = {
        jump_labels = true,
        jump = {
            autojump = true,
        },
    },
}
```