### PR TITLE
Fix abort to use Util.exit()

### DIFF
--- a/lua/flash/plugins/treesitter.lua
+++ b/lua/flash/plugins/treesitter.lua
@@ -125,7 +125,7 @@ function M.jump(opts)
 
   state:loop({
     abort = function()
-      vim.cmd([[normal! v]])
+      Util.exit()
     end,
     actions = {
       [";"] = function()
@@ -174,7 +174,11 @@ function M.search(opts)
   end)
 
   local state = Repeat.get_state("treesitter-search", opts)
-  state:loop()
+  state:loop({
+    abort = function()
+      Util.exit()
+    end,
+  })
   return state
 end
 


### PR DESCRIPTION
This fixes the bug where pressing `esc` would still execute a pending operator command.