### PR TITLE
fix(mapping): restore all modes for vim.v.operator

### DIFF
--- a/lua/flash/jump.lua
+++ b/lua/flash/jump.lua
@@ -104,18 +104,25 @@ function M.remote_op(match, state, register)
       vim.api.nvim_win_set_cursor(0, to)
     end
 
-    ---@diagnostic disable-next-line: param-type-mismatch
-    local opmap = vim.fn.maparg(vim.v.operator, "", false, true) --[[@as any]]
-    if not vim.tbl_isempty(opmap) then
-      vim.keymap.del("", vim.v.operator)
+    local maps = {
+      n = vim.fn.maparg(vim.v.operator, "n", false, true) --[[@as any]],
+      x = vim.fn.maparg(vim.v.operator, "x", false, true) --[[@as any]],
+      o = vim.fn.maparg(vim.v.operator, "o", false, true) --[[@as any]],
+    }
+    for mode, map in pairs(maps) do
+      if not vim.tbl_isempty(map) then
+        vim.keymap.del(mode, vim.v.operator)
+      end
     end
 
     -- re-trigger the operator
     vim.api.nvim_input('"' .. register .. vim.v.operator)
     if state.opts.remote_op.restore then
       vim.schedule(function()
-        if not vim.tbl_isempty(opmap) then
-          vim.fn.mapset(opmap.mode, false, opmap)
+        for mode, map in pairs(maps) do
+          if not vim.tbl_isempty(map) then
+            vim.fn.mapset(mode, false, map)
+          end
         end
         M.restore_remote(state)
       end)


### PR DESCRIPTION
## Description

`vim.fn.maparg` does not return all mappings when the mode param is `""`, it randomly return one modes from visual, normal and op-pending, thus later restore will randomly lose 2 of 3 mappings of `vim.v.operator` if there are defined
## Related Issue(s)
https://github.com/folke/flash.nvim/issues/165#issuecomment-1648879869


