### PR TITLE
feat(search): respect search direction in labeler

### DIFF
--- a/lua/flash/labeler.lua
+++ b/lua/flash/labeler.lua
@@ -144,10 +144,18 @@ function M:filter()
       local db = b.pos[1] * vim.go.columns + b.pos[2]
       return math.abs(dfrom - da) < math.abs(dfrom - db)
     end
+    ---@type boolean
+    local ahead
     if a.pos[1] ~= b.pos[1] then
-      return a.pos[1] < b.pos[1]
+      ahead = a.pos[1] < b.pos[1]
+    else
+      ahead = a.pos[2] < b.pos[2]
     end
-    return a.pos[2] < b.pos[2]
+    if self.state.opts.search.forward then
+      return ahead
+    else
+      return not ahead
+    end
   end)
   return ret
 end


### PR DESCRIPTION
## Description

I really like customizing the labels but for my telescope config it doesn't work because there was no way to set the direction for other windows. From the docs it seemed like the `search.forward` setting would change this but it did not.

This MR uses the `opts.search.forward` setting to pick the direction to label matches when searching windows.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

- Fixes #422 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

#### Before:

labels in telescope start at top even with `search.forward = false`
![image](https://github.com/user-attachments/assets/5da80e00-6241-4c73-9641-81253ed68ea6)


labels with reverse search (`?`) start at top (same as with `/`) [Note: this only applies when `distance = false`]
![image](https://github.com/user-attachments/assets/378a4f31-7431-49d0-a6fe-ae6ca4ddb6d1)



#### After:

labels in telescope start at bottom when you pass `search.forward = false`
![image](https://github.com/user-attachments/assets/3b8737fd-fb05-4f4b-8087-74216ac959cc)

labels with reverse search (`?`) start at bottom [Note: this only applies when `distance = false`]
![image](https://github.com/user-attachments/assets/901ddfd2-ca68-4d27-b23e-c13d0d7e94aa)


<!-- Add screenshots of the changes if applicable. -->

