### PR TITLE
docs(readme): update mappings examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Install the plugin with your preferred package manager:
   opts = {},
   -- stylua: ignore
   keys = {
-    { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
+    { "s", mode = { "n", "x" }, function() require("flash").jump() end, desc = "Flash" },
+    { 's', mode = { 'o' }, function() require('flash').jump { search = { multi_window = false } } end, desc = 'Flash' },
     { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
     { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
     { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },

--- a/doc/flash.nvim.txt
+++ b/doc/flash.nvim.txt
@@ -59,7 +59,8 @@ lazy.nvim <https://github.com/folke/lazy.nvim>
       opts = {},
       -- stylua: ignore
       keys = {
-        { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
+        { "s", mode = { "n", "x" }, function() require("flash").jump() end, desc = "Flash" },
+        { 's', mode = { 'o' }, function() require('flash').jump { search = { multi_window = false } } end, desc = 'Flash' },
         { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
         { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
         { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },

--- a/lua/flash/docs.lua
+++ b/lua/flash/docs.lua
@@ -19,7 +19,8 @@ function M.suggested()
     opts = {},
     -- stylua: ignore
     keys = {
-      { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end, desc = "Flash" },
+      { "s", mode = { "n", "x" }, function() require("flash").jump() end, desc = "Flash" },
+      { 's', mode = { 'o' }, function() require('flash').jump { search = { multi_window = false } } end, desc = 'Flash' },
       { "S", mode = { "n", "x", "o" }, function() require("flash").treesitter() end, desc = "Flash Treesitter" },
       { "r", mode = "o", function() require("flash").remote() end, desc = "Remote Flash" },
       { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end, desc = "Treesitter Search" },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

The example mappings, which most likely are the ones used by default for the majority of users, map the `s` in these modes: `{ 'n', 'x', 'o' }. I came to realize the `'o'` operation pending mode is not useful with the same configuration as the `'n'` and `'x'` modes. Actions like delete, change, yank, etc are not very useful when multi window is on, so I am updating the mapping for `'o'` mode using `multi_window = false`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

