### PR TITLE
feat(char): new option do_first_jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Install the plugin with your preferred package manager:
     max_length = false, ---@type number|false
   },
   jump = {
+    -- whether or not to do the first jump automatically
+    do_first_jump = true,
     -- save location in the jumplist
     jumplist = true,
     -- jump position

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Install the plugin with your preferred package manager:
       "cmp_menu",
       "noice",
       "flash_prompt",
+      "blink-cmp-menu",
       function(win)
         -- exclude non-focusable windows
         return not vim.api.nvim_win_get_config(win).focusable

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Install the plugin with your preferred package manager:
     max_length = false, ---@type number|false
   },
   jump = {
-    -- whether or not to do the first jump automatically
+    -- Whether or not to do the first jump automatically
+    -- This options will only affect char mode
     do_first_jump = true,
     -- save location in the jumplist
     jumplist = true,

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -36,6 +36,7 @@ local defaults = {
       "cmp_menu",
       "noice",
       "flash_prompt",
+      "blink-cmp-menu",
       function(win)
         -- exclude non-focusable windows
         return not vim.api.nvim_win_get_config(win).focusable

--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -52,6 +52,9 @@ local defaults = {
     max_length = false, ---@type number|false
   },
   jump = {
+    -- Whether or not to do the first jump automatically,
+    -- This options will only affect char mode
+    do_first_jump = true,
     -- save location in the jumplist
     jumplist = true,
     -- jump position

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -121,7 +121,6 @@ function M.setup()
         if Repeat.is_repeat then
           M.jump_labels = false -- never show jump labels when repeating
           M.state:jump({ count = vim.v.count1 })
-          M.state:show()
         else
           M.jump(key)
         end

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -239,7 +239,7 @@ function M.jump(key)
   M.state:update({ force = true })
 
   if M.jump_labels then
-    if Config.get("char").jump.autojump and #M.state.results == 1 then
+    if Config.get("char").jump.autojump and #M.state.results == 1 or #M.state.results == 0 then
       M.state:hide()
       return M.state
     end

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -232,24 +232,28 @@ function M.jump(key)
     M.state:update({ pattern = M.char })
   end
 
+  local do_first_jump = Config.get("char").jump.do_first_jump
   M.jump_labels = Config.get("char").jump_labels
-  if Config.get("char").jump.do_first_jump then
+  if do_first_jump then
     parsed.jump()
   end
   M.state:update({ force = true })
 
   if M.jump_labels then
-    if Config.get("char").jump.autojump and #M.state.results == 1 then
-      if not Config.get("char").jump.do_first_jump then
+    local autojump = Config.get("char").jump.autojump
+    if
+      autojump and #M.state.results == 1
+      or autojump
+        and #M.state.results == 2
+        and (M.state.results[1].pos == M.state.pos or M.state.results[2].pos == M.state.pos)
+    then
+      if not do_first_jump then
         -- jump here to be consistent with the autojump configuration
         parsed.jump()
       end
       M.state:hide()
       return M.state
-    elseif #M.state.results == 0 then
-      M.state:hide()
-      return M.state
-    elseif #M.state.results == 1 and M.state.results[1].pos == M.state.pos then
+    elseif #M.state.results == 0 or #M.state.results == 1 and M.state.results[1].pos == M.state.pos then
       M.state:hide()
       return M.state
     end

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -233,10 +233,7 @@ function M.jump(key)
     M.state:update({ pattern = M.char })
   end
 
-  local jump = parsed.jump
-
   M.jump_labels = Config.get("char").jump_labels
-  jump()
   M.state:update({ force = true })
 
   if M.jump_labels then

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -234,6 +234,9 @@ function M.jump(key)
   end
 
   M.jump_labels = Config.get("char").jump_labels
+  if Config.get("char").jump.do_first_jump then
+    parsed.jump()
+  end
   M.state:update({ force = true })
 
   if M.jump_labels then

--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -239,7 +239,17 @@ function M.jump(key)
   M.state:update({ force = true })
 
   if M.jump_labels then
-    if Config.get("char").jump.autojump and #M.state.results == 1 or #M.state.results == 0 then
+    if Config.get("char").jump.autojump and #M.state.results == 1 then
+      if not Config.get("char").jump.do_first_jump then
+        -- jump here to be consistent with the autojump configuration
+        parsed.jump()
+      end
+      M.state:hide()
+      return M.state
+    elseif #M.state.results == 0 then
+      M.state:hide()
+      return M.state
+    elseif #M.state.results == 1 and M.state.results[1].pos == M.state.pos then
       M.state:hide()
       return M.state
     end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

With setting `do_fist_jump` to `false`, and when you use `f`, `F`, `t` or `T` to search, it will not jump untill you input one label.

Besides, we add `blink-cmp-menu` to the exclude filetypes.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

```
|xxx word1 word2 word3
# use 'fw' with this option on
xxx |word1 word2 word3
# use 'fw' with this option off, now you can input a label to where you want
|xxx word1 word2 word3
```

We also update the `autojump` and fix some bugs:

* hide state when there is no match or only one match which is current position;
* auto jump when there are two matches one of which is current position;
