### PR TITLE
feat: Add keymap description

### DIFF
--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -133,6 +133,7 @@ function M.setup()
         end)
       end, {
         silent = true,
+        desc = "Flash built-in",
       })
     end
   end


### PR DESCRIPTION
## Description

Add the description "Flash built-in" to the keymaps overridden by Flash (f, F, t, T, ;, ,) to improve visibility when searching keymaps in Telescope. Without a description, these appear as \<anonymous>, which is not informative.

## Screenshots

### Before

![Screenshot_20250527_220420](https://github.com/user-attachments/assets/6e7133ec-fcbe-4054-b129-34ecc4409f29)

### After

![Screenshot_20250527_220132](https://github.com/user-attachments/assets/07452dc2-f1e7-4293-addc-c5bb355add28)
