### PR TITLE
feat(jump): display unique labels at different windows of the same buffer position

### DIFF
--- a/lua/flash/cache.lua
+++ b/lua/flash/cache.lua
@@ -48,6 +48,7 @@ function M:update()
   end
 
   self:_update_wins()
+  self:_update_ns()
 
   for _, w in ipairs(self.state.wins) do
     if self:_dirty(w) then
@@ -122,6 +123,19 @@ function M:_update_wins()
     end, vim.api.nvim_tabpage_list_wins(0))
     if keep_current then
       table.insert(self.state.wins, 1, self.state.win)
+    end
+  end
+end
+
+function M:_update_ns()
+  for _, win in ipairs(self.state.wins) do
+    if not self.state.ns[win] then
+      self.state.ns[win] = vim.api.nvim_create_namespace(string.format("%s.%d", (self.state.opts.ns or "flash"), win))
+      if vim.api.nvim__ns_set then
+        vim.api.nvim__ns_set(self.state.ns[win], { wins = { win } } )
+      elseif vim.api.nvim__win_add_ns then
+        vim.api.nvim__win_add_ns(win, self.state.ns[win])
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
This PR increases the ability to navigate between multiple windows having overlapped area of the same buffer. Although the matches are organized by window-position, the highlighter cannot display them all because the Neovim extmarks are created per buffer instead of per window.

However, Neovim supports window-scoped namespace since v0.10.0. The `vim.api.nvim_buf_set_extmark` can accept additional `scoped` option to display extmarks at specified scope.

The main idea is to make the namespace local to the windows. The extmarks are created based on the namespace of the window. All the matches can be displayed even if they are at the same buffer position. The compatibility before Neovim v0.10.0 still remains by filtering out the overlapped buffer positions as usual.

## Related Issue(s)

## Screenshots
As-is (before 0.10.0)
<img width="1411" height="371" alt="as-is-before-0 10 0" src="https://github.com/user-attachments/assets/67f79bc4-1e76-4776-baa7-24d595404c9a" />

As-is (after 0.10.0)
<img width="1411" height="372" alt="as-is-after-0 10 0" src="https://github.com/user-attachments/assets/147885c2-4376-481d-994a-85352e72b8a4" />

To-be (before 0.10.0)
<img width="1411" height="370" alt="to-be-before-0 10 0" src="https://github.com/user-attachments/assets/b09b516a-ccb5-48d2-8303-c3ffc1bf1f18" />

To-be (after 0.10.0)
<img width="1411" height="371" alt="to-be-after-0 10 0" src="https://github.com/user-attachments/assets/45f19583-3933-46ac-8a1b-2e0a0b8ec202" />