### PR TITLE
fix: force incremental=false for char mode

### DIFF
--- a/lua/flash/plugins/char.lua
+++ b/lua/flash/plugins/char.lua
@@ -39,6 +39,7 @@ function M.new()
       multi_window = false,
       mode = M.mode(M.motion),
       max_length = 1,
+      incremental = false,
     },
     prompt = {
       enabled = false,


### PR DESCRIPTION
## Description

Forces `incremental=false` to fix `char` mode pending commands being applied from the first to the chosen label, rather than from the cursor position to the chosen label.

## Related Issue(s)

Fixes #442 
