### PR TITLE
fix(window): set floating window border to none

### DIFF
--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -243,6 +243,7 @@ local defaults = {
     prefix = { { "⚡", "FlashPromptIcon" } },
     win_config = {
       relative = "editor",
+      border = "none",
       width = 1, -- when <=1 it's a percentage of the editor width
       height = 1,
       row = -1, -- when negative it's an offset from the bottom


### PR DESCRIPTION
- Explicitly windows border to none to avoid interference from `vim.o.winborder`


