### PR TITLE
feat(jump): add `exit_on_no_match` option to prevent aborting on no results

### DIFF
--- a/lua/flash/config.lua
+++ b/lua/flash/config.lua
@@ -135,6 +135,8 @@ local defaults = {
   pattern = "",
   -- When `true`, flash will try to continue the last search
   continue = false,
+  -- When `true`, flash will exit if there are no matches
+  exit_on_no_match = true,
   -- Set config to a function to dynamically change the config
   config = nil, ---@type fun(opts:Flash.Config)|nil
   -- You can override the default options for a specific mode.

--- a/lua/flash/state.lua
+++ b/lua/flash/state.lua
@@ -13,6 +13,7 @@ local Search = require("flash.search")
 local Util = require("flash.util")
 
 ---@class Flash.State.Config: Flash.Config
+---@field exit_on_no_match? boolean
 ---@field matcher? fun(win: window, state:Flash.State, pos: {from:Pos, to:Pos}): Flash.Match[]
 ---@field filter? fun(matches:Flash.Match[], state:Flash.State): Flash.Match[]
 ---@field pattern? string
@@ -411,7 +412,12 @@ function M:step(opts)
   end
 
   -- exit if no results and not in regular search mode
-  if #self.results == 0 and not self.pattern:empty() and self.pattern.mode ~= "search" then
+  if
+    self.opts.exit_on_no_match == true
+    and #self.results == 0
+    and not self.pattern:empty()
+    and self.pattern.mode ~= "search"
+  then
     if self.opts.search.incremental then
       vim.api.nvim_input(c)
     end


### PR DESCRIPTION
## Description

This is heavily related to https://github.com/folke/flash.nvim/issues/274. 

When one is in jump mode whether by directly entering it via `s` or by executing a command like `yr`, the default behavior is that once there is no match, the mode is just executed and the operator is just completely dumped.

This is problematic because if i type fast and i have a typo, this means that after there is no match i will absolutely mess up my file in normal mode as all letters i type, thinking they are in jump mode, will be interpreted as commands in normal mode.

To this end i implemented a small feature allowing the user to decide if he wants to always immediately quit the search/jump mode if there is no match or if he prefers that the mode is only left on pressing exit (or a valid label). This has two advantages: 1. I dont mess up my file, 2. I can press backspace if i realize my typo and continue with the command.
The option is called `exit_on_no_match` and is by default `true` so that the default behavior remains unchanged. 

## Related Issue(s)

https://github.com/folke/flash.nvim/issues/274