### PR TITLE
fix(labeler): add escaping to regex and made label only unique in the view

### DIFF
--- a/lua/flash/labeler.lua
+++ b/lua/flash/labeler.lua
@@ -88,8 +88,7 @@ function M:label(m, used)
   if label and self:valid(label) then
     self:use(label)
     local reuse = self.state.opts.label.reuse == "all"
-      or (self.state.opts.label.reuse == "lowercase" and label:lower() == label)
-
+      or (self.state.opts.label.reuse == "lowercase" and label:match("^[a-z]$") ~= nil)
     if reuse then
       self.used[pos] = label
     end

--- a/lua/flash/labeler.lua
+++ b/lua/flash/labeler.lua
@@ -177,14 +177,26 @@ function M:skip(win, labels)
   end
 
   vim.api.nvim_win_call(win, function()
+    local info = vim.fn.getwininfo(win)[1]
     while #labels > 0 do
-      -- this is needed, since an uppercase label would trigger smartcase
       local label_group = table.concat(labels, "")
       if vim.go.ignorecase then
         label_group = label_group:lower()
       end
-
-      local p = "\\%(" .. pattern .. "\\)\\m\\zs[" .. label_group .. "]"
+      local escaped = label_group:gsub("([\\^%-])", "\\%1"):gsub("[%[%]%%]", function(c)
+        return string.format("\\x%02x", c:byte())
+      end)
+      local p = "\\%>"
+        .. (info.topline - 1)
+        .. "l"
+        .. "\\%<"
+        .. (info.botline + 1)
+        .. "l"
+        .. "\\%("
+        .. pattern
+        .. "\\)\\m\\zs["
+        .. escaped
+        .. "]"
       local pos
       ok, pos = pcall(vim.fn.searchpos, p, "cnw")
 


### PR DESCRIPTION
## Description

Mainly this fixes https://github.com/folke/flash.nvim/issues/477 
That is  it allows special characters as labels without unpredictable behavior.

It also makes the label not  unique in the whole buffer but only whats visible by searching only in the visible region for matches and guaranteeing uniqueness for those matches.

## Related Issue(s)

fixes https://github.com/folke/flash.nvim/issues/477