### PR TITLE
fix(search): lagging labels

### DIFF
--- a/lua/flash/plugins/search.lua
+++ b/lua/flash/plugins/search.lua
@@ -54,6 +54,15 @@ function M.update(check_jump)
     pattern = vim.fn.getreg("/") .. pattern:sub(2)
   end
   M.state:update({ pattern = pattern, check_jump = check_jump })
+
+  -- Since Neovim 0.12 the incsearch redraw fires before CmdlineChanged
+  -- No redraw is triggered until the next key input, leaving outdated labels
+  -- This forces a redraw to realign the labels
+  if vim.api.nvim__redraw then
+    vim.api.nvim__redraw({ flush = true })
+  else
+    vim.cmd("redraw")
+  end
 end
 
 function M.start()


### PR DESCRIPTION
## Description

The Neovim 0.12 update changed the redraw logic, causing the search labels to lag behind by one keypress. A forced redraw has been applied to the search code to resolve the visually lagging search label issue. 

## Related Issue(s)
I believe this resolves #457 and #480 

## Screenshots
N/A

