### PR TITLE
fix(hacks): use new search state structure for neovim 0.13+

### DIFF
--- a/lua/flash/hacks.lua
+++ b/lua/flash/hacks.lua
@@ -9,7 +9,7 @@ local incsearch_state = {}
 local function _ffi()
   if not C then
     local ffi = require("ffi")
-    if vim.fn.has("nvim-0.13") then
+    if vim.fn.has("nvim-0.13") == 1 then
       ffi.cdef([[
       typedef struct {
         bool hl_match;
@@ -40,7 +40,7 @@ local function _ffi()
 end
 
 local function _get_search_match_lines()
-  if vim.fn.has("nvim-0.13") then
+  if vim.fn.has("nvim-0.13") == 1 then
     return C.Search.match_lines
   else
     return C.search_match_lines
@@ -48,7 +48,7 @@ local function _get_search_match_lines()
 end
 
 local function _set_search_match_lines(value)
-  if vim.fn.has("nvim-0.13") then
+  if vim.fn.has("nvim-0.13") == 1 then
     C.Search.match_lines = value
   else
     C.search_match_lines = value
@@ -56,7 +56,7 @@ local function _set_search_match_lines(value)
 end
 
 local function _get_search_match_endcol()
-  if vim.fn.has("nvim-0.13") then
+  if vim.fn.has("nvim-0.13") == 1 then
     return C.Search.match_endcol
   else
     return C.search_match_endcol
@@ -64,7 +64,7 @@ local function _get_search_match_endcol()
 end
 
 local function _set_search_match_endcol(value)
-  if vim.fn.has("nvim-0.13") then
+  if vim.fn.has("nvim-0.13") == 1 then
     C.Search.match_endcol = value
   else
     C.search_match_endcol = value

--- a/lua/flash/hacks.lua
+++ b/lua/flash/hacks.lua
@@ -9,15 +9,66 @@ local incsearch_state = {}
 local function _ffi()
   if not C then
     local ffi = require("ffi")
-    ffi.cdef([[
+    if vim.fn.has("nvim-0.13") then
+      ffi.cdef([[
+      typedef struct {
+        bool hl_match;
+        int32_t match_lines;
+        int match_endcol;
+        int32_t first_line;
+        int32_t last_line;
+        bool no_smartcase;
+        int cmdlen;
+        bool no_hlsearch;
+      } SearchState;
+
+      int no_mapping;
+      SearchState Search;
+      void setcursor_mayforce(bool force);
+    ]])
+    else
+      ffi.cdef([[
       int search_match_endcol;
       int no_mapping;
       unsigned int search_match_lines;
       void setcursor_mayforce(bool force);
     ]])
+    end
     C = ffi.C
   end
   return C
+end
+
+local function _get_search_match_lines()
+  if vim.fn.has("nvim-0.13") then
+    return C.Search.match_lines
+  else
+    return C.search_match_lines
+  end
+end
+
+local function _set_search_match_lines(value)
+  if vim.fn.has("nvim-0.13") then
+    C.Search.match_lines = value
+  else
+    C.search_match_lines = value
+  end
+end
+
+local function _get_search_match_endcol()
+  if vim.fn.has("nvim-0.13") then
+    return C.Search.match_endcol
+  else
+    return C.search_match_endcol
+  end
+end
+
+local function _set_search_match_endcol(value)
+  if vim.fn.has("nvim-0.13") then
+    C.Search.match_endcol = value
+  else
+    C.search_match_endcol = value
+  end
 end
 
 ---@private
@@ -25,8 +76,8 @@ end
 function M.get_end_pos(from)
   _ffi()
   local ret = Pos({
-    from[1] + C.search_match_lines,
-    math.max(0, C.search_match_endcol - 1),
+    from[1] + _get_search_match_lines(),
+    math.max(0, _get_search_match_endcol() - 1),
   })
   local line = vim.api.nvim_buf_get_lines(0, ret[1] - 1, ret[1], false)[1]
   local char_idx = vim.fn.charidx(line, ret[2])
@@ -37,8 +88,8 @@ end
 function M.save_incsearch_state()
   _ffi()
   incsearch_state = {
-    match_endcol = C.search_match_endcol,
-    match_lines = C.search_match_lines,
+    match_endcol = _get_search_match_endcol(),
+    match_lines = _get_search_match_lines(),
   }
 end
 
@@ -61,8 +112,8 @@ end
 
 function M.restore_incsearch_state()
   _ffi()
-  C.search_match_endcol = incsearch_state.match_endcol
-  C.search_match_lines = incsearch_state.match_lines
+  _set_search_match_endcol(incsearch_state.match_endcol)
+  _set_search_match_lines(incsearch_state.match_lines)
 end
 
 return M


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Adapted new search state structure introduced in https://github.com/neovim/neovim/commit/9bfa3378994fc121f2355f6b74de29e04d6aa73e, also added version check and a few wrappers to maintain compatibility with neovim 0.12 and lower.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #491.